### PR TITLE
feat(setup): add --append mode to preserve existing zshrc

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -5,28 +5,46 @@ if [ -z "$ZSH_CONFIG_DIR" ]; then
     ZSH_CONFIG_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 fi
 
-# Check if already configured
+# Parse optional --append flag
+APPEND_MODE=0
+if [ "$1" = "--append" ]; then
+    APPEND_MODE=1
+    shift
+fi
+
+# Check if already configured (protects both overwrite and append modes)
 if [ -f "$HOME/.zshrc" ] && grep -qF "source $ZSH_CONFIG_DIR/zshrc.sh" "$HOME/.zshrc"; then
     echo "Zsh config is already set up (found source line in ~/.zshrc)."
     echo "To force reinstall, remove ~/.zshrc and run again."
     exit 0
 fi
 
-# Back up old .zshrc file
-if [ -f "$HOME/.zshrc" ]; then
-    t=$(date +%s)
-    echo "Creating backup of old .zshrc file to ~/.zshrc.bak.$t"
-    mv "$HOME/.zshrc" "$HOME/.zshrc.bak.$t"
-fi
+if [ "$APPEND_MODE" -eq 1 ]; then
+    # Append mode: preserve existing .zshrc and add the zshconfig stanza at the end
+    cat >> "$HOME/.zshrc" <<EOF
 
-# Create .zshrc file
-cat > "$HOME/.zshrc" <<EOF
+# Added by zc setup --append
 export ZSH_CONFIG_DIR=$ZSH_CONFIG_DIR
 export PATH=\$ZSH_CONFIG_DIR:\$PATH
 source \$ZSH_CONFIG_DIR/zshrc.sh
 EOF
+    echo "Zsh config appended to existing ~/.zshrc. Please restart your terminal."
+else
+    # Default mode: back up any existing .zshrc and overwrite
+    if [ -f "$HOME/.zshrc" ]; then
+        t=$(date +%s)
+        echo "Creating backup of old .zshrc file to ~/.zshrc.bak.$t"
+        mv "$HOME/.zshrc" "$HOME/.zshrc.bak.$t"
+    fi
 
-echo "Zsh config setup complete. Please restart your terminal."
+    cat > "$HOME/.zshrc" <<EOF
+export ZSH_CONFIG_DIR=$ZSH_CONFIG_DIR
+export PATH=\$ZSH_CONFIG_DIR:\$PATH
+source \$ZSH_CONFIG_DIR/zshrc.sh
+EOF
+    echo "Zsh config setup complete. Please restart your terminal."
+fi
+
 echo ""
 echo "To use work configs:"
 echo "  zc workconfig list                 List work configs"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,5 +1,7 @@
 #!/bin/zsh
 
+set -e
+
 if [ -z "$ZSH_CONFIG_DIR" ]; then
     # Infer from script location
     ZSH_CONFIG_DIR="$(cd "$(dirname "$0")/.." && pwd)"
@@ -14,8 +16,12 @@ fi
 
 # Check if already configured (protects both overwrite and append modes)
 if [ -f "$HOME/.zshrc" ] && grep -qF "source $ZSH_CONFIG_DIR/zshrc.sh" "$HOME/.zshrc"; then
-    echo "Zsh config is already set up (found source line in ~/.zshrc)."
-    echo "To force reinstall, remove ~/.zshrc and run again."
+    if [ "$APPEND_MODE" -eq 1 ]; then
+        echo "Source line already present in ~/.zshrc — nothing to append."
+    else
+        echo "Zsh config is already set up (found source line in ~/.zshrc)."
+        echo "To force reinstall, remove ~/.zshrc and run again."
+    fi
     exit 0
 fi
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -29,6 +29,7 @@ export PATH=\$ZSH_CONFIG_DIR:\$PATH
 source \$ZSH_CONFIG_DIR/zshrc.sh
 EOF
     echo "Zsh config appended to existing ~/.zshrc. Please restart your terminal."
+    echo "Warning: conflicting configurations are possible — the appended stanza runs after your existing ~/.zshrc, so earlier PATH changes or plugin managers may shadow these additions."
 else
     # Default mode: back up any existing .zshrc and overwrite
     if [ -f "$HOME/.zshrc" ]; then


### PR DESCRIPTION
## Summary

Adds an optional `--append` flag to `scripts/setup.sh` for users who already have a customized `~/.zshrc` and would rather have the zshconfig stanza appended than have their file replaced.

### Behavior

- **Default (no flag):** unchanged — backs up any existing `~/.zshrc` to `~/.zshrc.bak.<timestamp>` and writes a fresh file.
- **`--append`:** skips the backup and appends the three-line stanza (preceded by a blank line and a `# Added by zc setup --append` marker comment so the origin is clear) to whatever is already in `~/.zshrc`.

The existing "already configured" guard (`grep -qF "source $ZSH_CONFIG_DIR/zshrc.sh"` against `~/.zshrc`) runs before the mode branches, so it protects both paths identically from duplicate entries. `shift` is used after detecting the flag so future positional arguments still work.

## Test plan

- [ ] `zc setup` on a machine with no `~/.zshrc` writes the three-line file as before
- [ ] `zc setup` on a machine with an existing `~/.zshrc` creates `~/.zshrc.bak.<timestamp>` and overwrites
- [ ] `zc setup --append` on a machine with an existing `~/.zshrc` leaves the original content intact and appends the marked stanza at the end
- [ ] Re-running either mode after setup is a no-op (guard fires)